### PR TITLE
update albert version

### DIFF
--- a/gector/gec_model.py
+++ b/gector/gec_model.py
@@ -34,7 +34,7 @@ def get_weights_name(transformer_name, lowercase):
     if transformer_name == 'albert':
         if not lowercase:
             print('Warning! This model was trained only on uncased sentences.')
-        return 'albert-base-v1'
+        return 'albert-base-v2'
     if lowercase:
         print('Warning! This model was trained only on cased sentences.')
     if transformer_name == 'roberta':


### PR DESCRIPTION
bugfix: 
albert-base-v1 didn't run. May you can take a look why the v2 version of albert is the only currently working.
Using albert-base-v1 causes following error: "RuntimeError: Internal: /sentencepiece/src/sentencepiece_processor.cc(818) [model_proto->ParseFromArray(serialized.data(), serialized.size())]"

---
I want to mention that I do not fully understand the impact of updating the albert version. I only wanted to mention the "bug" so that other don't have to search through the code like I did to train the model with albert as base. 