### PR TITLE
Update to python 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 torch==1.10.0
-allennlp==0.8.4
+allennlp==0.9.0
 python-Levenshtein==0.12.1
 transformers==4.11.3
-scikit-learn==0.22.0
+scikit-learn==0.24.2
 sentencepiece==0.1.95
 overrides==4.1.2
-numpy==1.19.5
+numpy==1.23.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ torch==1.10.0
 allennlp==0.8.4
 python-Levenshtein==0.12.1
 transformers==4.11.3
-scikit-learn==0.20.0
+scikit-learn==0.22.0
 sentencepiece==0.1.95
 overrides==4.1.2
 numpy==1.19.5


### PR DESCRIPTION
Update Python 3.7 to 3.8 by changing sklearn version to 0.22. See [here](https://github.com/joblib/joblib/issues/917) for resolving Python 3.8 compatibility. 
Also compared the predicted results from the outputs of 3.8 version to the Python 3.7 on the BEA data and no differences found. 